### PR TITLE
Restore PHP 5.3 compatibility

### DIFF
--- a/tcpdf.php
+++ b/tcpdf.php
@@ -15192,7 +15192,7 @@ class TCPDF {
 	 * @since 3.1.000 (2008-06-09)
 	 * @public
 	 */
-	public function write1DBarcode($code, $type, $x='', $y='', $w='', $h='', $xres='', $style=[], $align='') {
+	public function write1DBarcode($code, $type, $x='', $y='', $w='', $h='', $xres='', $style=array(), $align='') {
 		if (TCPDF_STATIC::empty_string(trim($code))) {
 			return;
 		}


### PR DESCRIPTION
composer.json for TCPDF claims support for PHP 5.3 and short array syntax is not in this old version. This undos commit 865cd727fc29b080e8da1959566de5078a605c73 in char101:patch-1